### PR TITLE
Custom Character/Instrument dta autorun script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -408,3 +408,4 @@ FodyWeavers.xsd
 *.vsix
 
 Properties/*.json
+.DS_Store

--- a/Source/char_hook.dta
+++ b/Source/char_hook.dta
@@ -1,0 +1,55 @@
+#define CUSTOM_CHAR_HOOK
+(
+   {ui foreach_screen $screen
+      {$screen foreach_panel $panel
+         {if {$panel loaded_dir}
+            {{$panel loaded_dir} iterate RndDir $b
+               {$b iterate BandCharacter $c
+                  {$c iterate RndDir $y
+                     {if {|| {== $y outfit} {== $y instrument}}
+                        {do
+                           ($found_custom FALSE)
+                           {set_this $y}
+                           {$this iterate Mesh $m
+                              {if {has_substr {$m name} "gltf_"}
+                                 {set $found_custom TRUE}
+                              }
+                           }
+                           {if $found_custom
+                              {$this iterate Mesh $m
+                                 {if {! {has_substr {$m name} "gltf_"}}
+                                    {$m set_showing FALSE}
+                                 }
+                              }
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+)
+;ensure we don't push into something that doesn't exist
+{if {find_exists $syscfg objects BandCamShot types band start_shot}
+   {if {! $char_exec}
+      ;dont push multiple times
+      {set $char_exec TRUE}
+      {push_back {find $syscfg objects BandCamShot types band start_shot}
+         {quote
+            CUSTOM_CHAR_HOOK
+         }
+      }
+      {push_back {find $syscfg objects BandCamShot types band3 start_shot}
+         {quote
+            CUSTOM_CHAR_HOOK
+         }
+      }
+      {push_back {find $syscfg objects BandCamShot types closet start_shot}
+         {quote
+            CUSTOM_CHAR_HOOK
+         }
+      }
+   }
+}

--- a/Source/char_hook.dta
+++ b/Source/char_hook.dta
@@ -1,24 +1,30 @@
-#define CUSTOM_CHAR_HOOK
-(
-   {ui foreach_screen $screen
-      {$screen foreach_panel $panel
-         {if {$panel loaded_dir}
-            {{$panel loaded_dir} iterate RndDir $b
-               {$b iterate BandCharacter $c
-                  {$c iterate RndDir $y
-                     {if {|| {== $y outfit} {== $y instrument}}
-                        {do
-                           ($found_custom FALSE)
-                           {set_this $y}
-                           {$this iterate Mesh $m
-                              {if {has_substr {$m name} "gltf_"}
-                                 {set $found_custom TRUE}
-                              }
-                           }
-                           {if $found_custom
-                              {$this iterate Mesh $m
-                                 {if {! {has_substr {$m name} "gltf_"}}
-                                    {$m set_showing FALSE}
+;ensure we don't push into something that doesn't exist
+{if {! $char_exec}
+   ;dont push multiple times
+   {set $char_exec TRUE}
+   {foreach $elem (band band3 closet)
+      {push_back {find $syscfg objects BandCamShot types $elem start_shot}
+         {quote
+            {ui foreach_screen $screen
+               {$screen foreach_panel $panel
+                  {if {$panel loaded_dir}
+                     {{$panel loaded_dir} iterate RndDir $b
+                        {$b iterate BandCharacter $c
+                           {$c iterate RndDir $y
+                              {do
+                                 ($found_custom FALSE)
+                                 {set_this $y}
+                                 {$this iterate Mesh $m
+                                    {if {has_substr {$m name} "gltf_"}
+                                       {set $found_custom TRUE}
+                                    }
+                                 }
+                                 {if $found_custom
+                                    {$this iterate Mesh $m
+                                       {if {! {has_substr {$m name} "gltf_"}}
+                                          {$m set_showing FALSE}
+                                       }
+                                    }
                                  }
                               }
                            }
@@ -27,28 +33,6 @@
                   }
                }
             }
-         }
-      }
-   }
-)
-;ensure we don't push into something that doesn't exist
-{if {find_exists $syscfg objects BandCamShot types band start_shot}
-   {if {! $char_exec}
-      ;dont push multiple times
-      {set $char_exec TRUE}
-      {push_back {find $syscfg objects BandCamShot types band start_shot}
-         {quote
-            CUSTOM_CHAR_HOOK
-         }
-      }
-      {push_back {find $syscfg objects BandCamShot types band3 start_shot}
-         {quote
-            CUSTOM_CHAR_HOOK
-         }
-      }
-      {push_back {find $syscfg objects BandCamShot types closet start_shot}
-         {quote
-            CUSTOM_CHAR_HOOK
          }
       }
    }

--- a/Source/char_hook.dta
+++ b/Source/char_hook.dta
@@ -1,5 +1,5 @@
 ;ensure we don't push into something that doesn't exist
-{if {! $char_exec}
+{if {&& {! $char_exec} {find_exists $syscfg objects BandCamShot types band start_shot}}
    ;dont push multiple times
    {set $char_exec TRUE}
    {foreach $elem (band band3 closet)


### PR DESCRIPTION
This script is meant to be embedded into a custom character/instrument milo as an #autorun

This will ensure the proper syscfg array exists, and pushes back a hook into "start_shot" for band, band3, and closet types

The hook iterates character meshes and if any have "gltf_" in the file name, it is assumed a custom object is loaded to the character.

All other meshes, including clothing, and base body parts are hidden, so only the custom props remain.

also ignore .DS_Store because i use macOS btw