### PR TITLE
Fix argument parsing failures being ignored

### DIFF
--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -6,28 +6,30 @@ namespace glTFMilo.Source
     {
         static void Main(string[] args)
         {
-            var res = Parser.Default.ParseArguments<Options>(args);
+            Parser.Default.ParseArguments<Options>(args).WithParsed((options) =>
+            {
+                // Sanity check
+                if (options == null)
+                {
+                    Console.WriteLine("Unknown error from parsing arguments");
+                    return;
+                }
 
-            // if res.Value.Input ends in a milo extension, we run Program
-            // if it ends in a glb or gltf extension, we run Program
-            if (res == null)
-            {
-                Console.WriteLine("Error parsing arguments");
-                return;
-            }
-
-            if (res.Value.Input.EndsWith(".milo_xbox", StringComparison.OrdinalIgnoreCase))
-            {
-                MiloGLTFUtils.Source.MiloglTF.Program.Run(res.Value);
-            }
-            else if (res.Value.Input.EndsWith(".glb", StringComparison.OrdinalIgnoreCase) || res.Value.Input.EndsWith(".gltf", StringComparison.OrdinalIgnoreCase))
-            {
-                MiloGLTFUtils.Source.glTFMilo.Program.Run(res.Value);
-            }
-            else
-            {
-                Console.WriteLine("Unsupported file type. Please provide a .milo, .glb, or .gltf file.");
-            }
+                // if res.Value.Input ends in a milo extension, we run Program
+                // if it ends in a glb or gltf extension, we run Program
+                if (options.Input.EndsWith(".milo_xbox", StringComparison.OrdinalIgnoreCase))
+                {
+                    MiloGLTFUtils.Source.MiloglTF.Program.Run(options);
+                }
+                else if (options.Input.EndsWith(".glb", StringComparison.OrdinalIgnoreCase) || options.Input.EndsWith(".gltf", StringComparison.OrdinalIgnoreCase))
+                {
+                    MiloGLTFUtils.Source.glTFMilo.Program.Run(options);
+                }
+                else
+                {
+                    Console.WriteLine("Unsupported file type. Please provide a .milo, .glb, or .gltf file.");
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
Uses the `WithParsed` extension method instead of handling the `ParserResult` value manually.